### PR TITLE
[#48] Scale pin preview images

### DIFF
--- a/pin-cushion.css
+++ b/pin-cushion.css
@@ -1,6 +1,5 @@
 .pin-cushion-hud #container {
     background-color: rgba(255, 255, 255, 0.9);
-    /*height: 200px;*/
     overflow: hidden;
     padding: 2px;
     border: 1px solid black;
@@ -10,6 +9,11 @@
 .pin-cushion-hud #content {
     text-overflow: ellipsis;
     text-align: left;
+}
+
+.pin-cushion-hud img {
+    object-fit: scale-down;
+    max-height: 250px;
 }
 
 /* About App */


### PR DESCRIPTION
Fixes #48

Added css for img in previews to scale down in size.

Before and after comparison:
![before-after](https://user-images.githubusercontent.com/6009785/114306078-f8a45780-9ada-11eb-8fb7-cc508f3bb1e5.png)
