### PR TITLE
Foundry 0.8.6 compatibility

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1,8 +1,6 @@
 {
     "SETTINGS.AboutAppN": "About Pin Cushion",
     "SETTINGS.AboutAppH": "Displays additional info about Pin Cushion",
-    "SETTINGS.AllowPlayerNotesN": "Allow Player Notes",
-    "SETTINGS.AllowPlayerNotesH": "Allows players to create map pins",
     "SETTINGS.ShowJournalPreviewN": "Show Journal Preview",
     "SETTINGS.ShowJournalPreviewH": "Shows a Journal preview when hovering over a map pin",
     "SETTINGS.PreviewTypeN": "Journal Preview Type",

--- a/lang/en.json
+++ b/lang/en.json
@@ -20,7 +20,7 @@
         "PerUser": "Per User",
         "Folder": "Journal Entry Folder:",
         "ExistingFolders": "Existing Folders",
-        "DefaultPermission": "Default Permission:",
+        "DefaultPermission": "Default Permission (for all players):",
         "CreateMissingFoldersT": "Create Missing Folders",
         "CreateMissingFoldersC": "<b>Create a Journal Entry folder for each player?</b><br>This ensures that each player has their own folder for entries to be created in.",
 

--- a/module.json
+++ b/module.json
@@ -3,8 +3,8 @@
     "title": "Pin Cushion",
     "description": "Adds additional map pin (Journal Note/Scene Note) functionality",
     "version": "1.4.0",
-    "minimumCoreVersion": "0.7.5",
-    "compatibleCoreVersion": "0.7.9",
+    "minimumCoreVersion": "0.8.6",
+    "compatibleCoreVersion": "0.8.6",
     "author": "Evan Clarke [errational#2007]",
     "authors": [
         {

--- a/pin-cushion.js
+++ b/pin-cushion.js
@@ -268,7 +268,18 @@ class PinCushion {
             return;
         }
 
+        // Silently return when note creation permissions are missing
         if (!game.user.can("NOTE_CREATE")) return;
+
+        // Warn user when notes can be created, but journal entries cannot
+        if (!game.user.can("JOURNAL_CREATE")) {
+            ui.notifications.warn(
+                game.i18n.format("PinCushion.Warn.AllowPlayerNotes", {
+                    permission: game.i18n.localize("PERMISSION.JournalCreate"),
+                })
+            );
+            return;
+        }
 
         const data = {
             clientX: event.data.global.x,

--- a/pin-cushion.js
+++ b/pin-cushion.js
@@ -127,7 +127,7 @@ class PinCushion {
                 // Since only the ID is required, instantiating a Folder from the data is not necessary
                 folder = (await PinCushion.requestEvent({ action: "createFolder" }))?._id;
             }
-        } else folder = selectedFolder;
+        } else folder = selectedFolder; // Folder is already given as ID
 
         const entry = await JournalEntry.create({name: `${input[0].value}`, permission, ...folder && {folder}});
 
@@ -135,6 +135,7 @@ class PinCushion {
             return;
         }
 
+        // Manually add fields required by Foundry's drop handling
         const entryData = entry.data.toJSON();
         entryData.id = entry.id;
         entryData.type = "JournalEntry";
@@ -253,7 +254,7 @@ class PinCushion {
         iconSelector.replaceWith(filePickerHtml);
 
         // Detect and activate file-picker buttons
-        html.find("button.file-picker").each((i, button) => button.onclick = app._activateFilePicker.bind(app));
+        html.find("button.file-picker").on("click", app._activateFilePicker.bind(app));
     }
 
     /* -------------------------------- Listeners ------------------------------- */


### PR DESCRIPTION
This PR makes Pin Cushion compatible with Foundry 0.8.6.

Most smaller changes deal with differing data layouts or moved values (`CONST`, `isOwner`, etc.).

The big deleted chunks dealt with the creation, modification, and deletion of notes, which has now been folded into Foundry itself (0.8.6 resolved a major bug in the permission handling).
The only socket part still necessary is the folder handling, as users cannot create folders themselves.

Note for users: This removes the Pin Cushion setting to allow player note creation, as this can now be configured with the "Create Map Notes" permission.