### PR TITLE
Fix a null ref for when there was a pin on the map that didn't have an entry

### DIFF
--- a/pin-cushion.js
+++ b/pin-cushion.js
@@ -468,6 +468,12 @@ class PinCushionHUD extends BasePlaceableHUD {
     getData() {
         const data = super.getData();
         const entry = this.object.entry;
+        if (!entry)
+        {
+            // Do nothing b/c this doesn't have an entry
+            return;
+        }
+
         const previewType = game.settings.get(PinCushion.MODULE_NAME, "previewType");
         let content;
 


### PR DESCRIPTION
This happened all the time for stuff with multilevel tokens to transport from one area of the map to another. 